### PR TITLE
supporting python 3.11+ wheels in CI

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.13"
+requires-python = ">=3.11"
 dependencies = [
     "tokamap>=0.1.0",
     "numpy>=2.0",


### PR DESCRIPTION
Adding python 3.11 and 3.12 to the CI for building pypi wheels. See #27 